### PR TITLE
Make internal system include directories available.

### DIFF
--- a/PVS-Studio.cmake
+++ b/PVS-Studio.cmake
@@ -125,9 +125,11 @@ endfunction ()
 function (pvs_studio_set_target_flags TARGET CXX C)
     set(CXX_FLAGS "${${CXX}}")
     set(C_FLAGS "${${C}}")
-
-    list(APPEND CXX_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
-    list(APPEND C_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
+    
+    if (NOT MSVC)
+        list(APPEND CXX_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
+        list(APPEND C_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
+    endif ()
 
     set(prop_incdirs "$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>")
     list(APPEND CXX_FLAGS "$<$<BOOL:${prop_incdirs}>:-I$<JOIN:${prop_incdirs},$<SEMICOLON>-I>>")

--- a/PVS-Studio.cmake
+++ b/PVS-Studio.cmake
@@ -126,8 +126,8 @@ function (pvs_studio_set_target_flags TARGET CXX C)
     set(CXX_FLAGS "${${CXX}}")
     set(C_FLAGS "${${C}}")
 
-    list(APPEND CXX_FLAGS "-isystem$<JOIN:${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES},$<SEMICOLON>-isystem>")
-    list(APPEND C_FLAGS "-isystem$<JOIN:${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES},$<SEMICOLON>-isystem>")
+    list(APPEND CXX_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
+    list(APPEND C_FLAGS "$<$<BOOL:${CMAKE_SYSROOT}>:--sysroot=${CMAKE_SYSROOT}>")
 
     set(prop_incdirs "$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>")
     list(APPEND CXX_FLAGS "$<$<BOOL:${prop_incdirs}>:-I$<JOIN:${prop_incdirs},$<SEMICOLON>-I>>")

--- a/PVS-Studio.cmake
+++ b/PVS-Studio.cmake
@@ -126,6 +126,9 @@ function (pvs_studio_set_target_flags TARGET CXX C)
     set(CXX_FLAGS "${${CXX}}")
     set(C_FLAGS "${${C}}")
 
+    list(APPEND CXX_FLAGS "-isystem$<JOIN:${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES},$<SEMICOLON>-isystem>")
+    list(APPEND C_FLAGS "-isystem$<JOIN:${CMAKE_C_IMPLICIT_INCLUDE_DIRECTORIES},$<SEMICOLON>-isystem>")
+
     set(prop_incdirs "$<TARGET_PROPERTY:${TARGET},INCLUDE_DIRECTORIES>")
     list(APPEND CXX_FLAGS "$<$<BOOL:${prop_incdirs}>:-I$<JOIN:${prop_incdirs},$<SEMICOLON>-I>>")
     list(APPEND C_FLAGS "$<$<BOOL:${prop_incdirs}>:-I$<JOIN:${prop_incdirs},$<SEMICOLON>-I>>")


### PR DESCRIPTION
When running in a Yocto SDK environment pvs-studio could not find internal
system headers while generating dependencies using gcc. Exact origin of
the issue is unknown. Probably has to do with the special environment
the sourced Yocto setup script generates.

Prefixing the system includes in the CXX_FLAGS and C_FLAGS as in this
patch makes the problem disappear.

Signed-off-by: Marc Bodmer <marc.bodmer@securiton.ch>